### PR TITLE
observe dynamic memory usage

### DIFF
--- a/src/common/bloom.h
+++ b/src/common/bloom.h
@@ -5,6 +5,7 @@
 #ifndef BITCOIN_COMMON_BLOOM_H
 #define BITCOIN_COMMON_BLOOM_H
 
+#include <memusage.h>
 #include <serialize.h>
 #include <span.h>
 
@@ -52,6 +53,8 @@ private:
     unsigned int Hash(unsigned int nHashNum, Span<const unsigned char> vDataToHash) const;
 
 public:
+    size_t DynamicUsage() const { return memusage::DynamicUsage(vData); }
+
     /**
      * Creates a new bloom filter which will provide the given fp rate when filled with the given number of elements
      * Note that if the given parameters will result in a filter outside the bounds of the protocol limits,
@@ -114,6 +117,8 @@ public:
     bool contains(Span<const unsigned char> vKey) const;
 
     void reset();
+
+    size_t DynamicUsage() const { return memusage::DynamicUsage(data); }
 
 private:
     int nEntriesPerGeneration;

--- a/src/headerssync.h
+++ b/src/headerssync.h
@@ -207,7 +207,7 @@ private:
     /** Return a set of headers that satisfy our proof-of-work threshold */
     std::vector<CBlockHeader> PopHeadersReadyForAcceptance();
 
-private:
+public:
     /** NodeId of the peer (used for log messages) **/
     const NodeId m_id;
 

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -735,6 +735,69 @@ V1Transport::V1Transport(const NodeId node_id, int nTypeIn, int nVersionIn) noex
     Reset();
 }
 
+size_t V1Transport::StaticMemoryUsage()
+{
+    size_t val = 0;
+    val += sizeof(m_magic_bytes);
+    val += sizeof(m_node_id);
+
+    val += sizeof(m_recv_mutex);
+    {
+        LOCK(m_recv_mutex);
+        val += sizeof(hasher);
+        val += sizeof(data_hash);
+        val += sizeof(in_data);
+        val += sizeof(hdrbuf);
+        val += sizeof(hdr);
+        val += sizeof(vRecv);
+        val += sizeof(nHdrPos);
+        val += sizeof(nDataPos);
+    }
+
+    val += sizeof(m_send_mutex);
+    {
+        LOCK(m_send_mutex);
+        val += sizeof(m_header_to_send);
+        val += sizeof(m_message_to_send);
+        val += sizeof(m_sending_header);
+        val += sizeof(m_bytes_sent);
+    }
+
+    return val;
+}
+
+size_t V1Transport::DynamicMemoryUsage()
+{
+    size_t val = 0;
+
+    {
+        LOCK(m_recv_mutex);
+        // for these two members that are CDataStreams, explicly add the dynamic
+        // memory usage of the internal vector
+        val += memusage::DynamicUsage(hdrbuf.vch);
+        val += memusage::DynamicUsage(vRecv.vch);
+    }
+
+    {
+        LOCK(m_send_mutex);
+        val += memusage::DynamicUsage(m_header_to_send);
+        val += memusage::DynamicUsage(m_message_to_send.data);
+        val += memusage::DynamicUsage(m_message_to_send.m_type);
+    }
+
+    return val;
+}
+
+size_t V2Transport::StaticMemoryUsage()
+{
+    return 0;
+}
+
+size_t V2Transport::DynamicMemoryUsage()
+{
+    return 0;
+}
+
 Transport::Info V1Transport::GetInfo() const noexcept
 {
     return {.transport_type = TransportProtocolType::V1, .session_id = {}};

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -3890,3 +3890,23 @@ std::function<void(const CAddress& addr,
                    Span<const unsigned char> data,
                    bool is_incoming)>
     CaptureMessage = CaptureMessageToFile;
+
+namespace memusage {
+size_t RecursiveDynamicUsage(const CNetMessage& msg)
+{
+    // MallocUsage of the m_type string
+    // and DynamicUsage(vector) calls MallocUsage(vector)
+    return MallocUsage(msg.m_type.capacity()) + DynamicUsage(msg.m_recv.vch);
+}
+
+size_t RecursiveDynamicUsage(const std::list<CNetMessage>& msg_list)
+{
+    size_t val = 0;
+    // MallocUsage of the list
+    val = DynamicUsage(msg_list);
+    for (auto& msg : msg_list) {
+        val += RecursiveDynamicUsage(msg);
+    }
+    return val;
+}
+}

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2058,6 +2058,11 @@ void CConnman::CreateNodeFromAcceptedSocket(std::unique_ptr<Sock>&& sock,
     pnode->AddRef();
     m_msgproc->InitializeNode(*pnode, nodeServices);
 
+    if(ABCDBool) {
+        ABCDBool = false;
+        LogPrintf("ABCD CNode::ConstantMemoryUsage - %d \n", pnode->ConstantMemoryUsage());
+    }
+
     LogPrint(BCLog::NET, "connection from %s accepted\n", addr.ToStringAddrPort());
 
     {

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -118,6 +118,132 @@ std::map<CNetAddr, LocalServiceInfo> mapLocalHost GUARDED_BY(g_maplocalhost_mute
 static bool vfLimited[NET_MAX] GUARDED_BY(g_maplocalhost_mutex) = {};
 std::string strSubVersion;
 
+size_t CNode::DynamicMemoryUsage() {
+    size_t val = 0;
+
+    // normally calling memusage::DynamicMemoryUsage(unique_ptr) will properly
+    // take the sizeof(thing_pointed_to)
+    // in this case, we have to manually add the StaticMemoryUsage because
+    // Transport is a virtual class, and only instantiated on constructing a
+    // CNode. since sizeof() is compile-time, it only has a virtual table
+    // lookup instead of a full class definition.
+    val += m_transport->StaticMemoryUsage();
+    val += m_transport->DynamicMemoryUsage();
+
+    {
+        // m_send_memusage should represent memory usage of vSendMsg (minus some ptrs)
+        LOCK(cs_vSend);
+        val += m_send_memusage;
+    }
+
+    val += memusage::DynamicUsage(m_addr_name);
+    val += memusage::DynamicUsage(m_dest);
+    WITH_LOCK(m_subver_mutex, val += memusage::DynamicUsage(cleanSubVer));
+
+    // vRecvMsg doesn't have a lock because its only used by the SocketHandler thread
+    // this introduces access via RPC thread. could that cause an issue?
+    val += memusage::RecursiveDynamicUsage(vRecvMsg);
+
+    {
+        // m_msg_process_queue_size should represent memory usage of m_msg_process_queue (minus some ptrs)
+        LOCK(m_msg_process_queue_mutex);
+        val += m_msg_process_queue_size;
+    }
+
+    WITH_LOCK(cs_vSend, val += memusage::DynamicUsage(mapSendBytesPerMsgType));
+    WITH_LOCK(cs_vRecv, val += memusage::DynamicUsage(mapRecvBytesPerMsgType));
+
+    {
+        LOCK(m_sock_mutex);
+        val += memusage::DynamicUsage(m_sock);
+        val += memusage::DynamicUsage(m_i2p_sam_session);
+    }
+
+    return val;
+}
+
+size_t CNode::ConstantMemoryUsage() {
+    size_t val = 0;
+    val += sizeof(m_transport);
+    val += sizeof(m_permission_flags);
+
+    val += sizeof(m_sock_mutex);
+    {
+        LOCK(m_sock_mutex);
+        val += sizeof(m_sock);
+        val += sizeof(m_i2p_sam_session);
+    }
+
+    val += sizeof(cs_vSend);
+    {
+        LOCK(cs_vSend);
+        val += sizeof(m_send_memusage);
+        val += sizeof(nSendBytes);
+        val += sizeof(vSendMsg);
+        val += sizeof(mapSendBytesPerMsgType);
+    }
+
+    val += sizeof(cs_vRecv);
+    {
+        LOCK(cs_vRecv);
+        val += sizeof(nRecvBytes);
+        val += sizeof(mapRecvBytesPerMsgType);
+    }
+
+    val += sizeof(m_last_send);
+    val += sizeof(m_last_recv);
+    val += sizeof(m_connected);
+    val += sizeof(nTimeOffset);
+
+    val += sizeof(addr);
+    val += sizeof(addrBind);
+    val += sizeof(m_addr_name);
+    val += sizeof(m_dest);
+    val += sizeof(m_inbound_onion);
+    val += sizeof(nVersion);
+
+    val += sizeof(m_subver_mutex);
+    WITH_LOCK(m_subver_mutex, val += sizeof(cleanSubVer));
+
+    val += sizeof(m_prefer_evict);
+    val += sizeof(fSuccessfullyConnected);
+    val += sizeof(fDisconnect);
+    val += sizeof(grantOutbound);
+    val += sizeof(nRefCount);
+    val += sizeof(nKeyedNetGroup);
+    val += sizeof(fPauseRecv);
+    val += sizeof(fPauseSend);
+    val += sizeof(m_conn_type);
+
+    val += sizeof(m_bip152_highbandwidth_to);
+    val += sizeof(m_bip152_highbandwidth_from);
+    val += sizeof(m_has_all_wanted_services);
+    val += sizeof(m_relays_txs);
+    val += sizeof(m_bloom_filter_loaded);
+    val += sizeof(m_last_block_time);
+    val += sizeof(m_last_tx_time);
+    val += sizeof(m_last_ping_time);
+    val += sizeof(m_min_ping_time);
+
+    val += sizeof(id);
+    val += sizeof(nLocalHostNonce);
+    val += sizeof(m_greatest_common_version);
+    val += sizeof(m_recv_flood_size);
+    val += sizeof(vRecvMsg);
+
+    val += sizeof(m_msg_process_queue_mutex);
+    {
+        LOCK(m_msg_process_queue_mutex);
+        val += sizeof(m_msg_process_queue);
+        val += sizeof(m_msg_process_queue_size);
+    }
+
+    val += sizeof(m_addr_local_mutex);
+    WITH_LOCK(m_addr_local_mutex, val += sizeof(addrLocal));
+
+    return val;
+}
+
 size_t CSerializedNetMsg::GetMemoryUsage() const noexcept
 {
     // Don't count the dynamic memory used for the m_type string, by assuming it fits in the

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -3698,6 +3698,14 @@ uint32_t CConnman::GetMappedAS(const CNetAddr& addr) const
     return m_netgroupman.GetMappedAS(addr);
 }
 
+void CConnman::GetNodeMemory(std::map<NodeId, size_t>& info) const
+{
+    LOCK(m_nodes_mutex);
+    for (CNode* pnode : m_nodes) {
+        info[pnode->GetId()] = pnode->DynamicMemoryUsage();
+    }
+}
+
 void CConnman::GetNodeStats(std::vector<CNodeStats>& vstats) const
 {
     vstats.clear();
@@ -4001,6 +4009,24 @@ bool CConnman::ForNode(NodeId id, std::function<bool(CNode* pnode)> func)
         }
     }
     return found != nullptr && NodeFullyConnected(found) && func(found);
+}
+
+std::string CConnman::NodeToString(NodeId id) const
+{
+    CNode* found = nullptr;
+    LOCK(m_nodes_mutex);
+    for (auto&& pnode : m_nodes) {
+        if(pnode->GetId() == id) {
+            found = pnode;
+            break;
+        }
+    }
+
+    if (found != nullptr) {
+        return ConnectionTypeAsString(found->m_conn_type);
+    } else {
+        return "";
+    }
 }
 
 CSipHasher CConnman::GetDeterministicRandomizer(uint64_t id) const

--- a/src/net.h
+++ b/src/net.h
@@ -772,6 +772,11 @@ public:
 
     const ConnectionType m_conn_type;
 
+    size_t DynamicMemoryUsage()
+        EXCLUSIVE_LOCKS_REQUIRED(!cs_vSend, !m_msg_process_queue_mutex, !cs_vRecv, !m_sock_mutex, !m_subver_mutex);
+    size_t ConstantMemoryUsage()
+        EXCLUSIVE_LOCKS_REQUIRED(!cs_vSend, !m_msg_process_queue_mutex, !cs_vRecv, !m_sock_mutex, !m_subver_mutex, !m_addr_local_mutex);
+
     /** Move all messages from the received queue to the processing queue. */
     void MarkReceivedMsgsForProcessing()
         EXCLUSIVE_LOCKS_REQUIRED(!m_msg_process_queue_mutex);

--- a/src/net.h
+++ b/src/net.h
@@ -281,6 +281,10 @@ public:
     /** Retrieve information about this transport. */
     virtual Info GetInfo() const noexcept = 0;
 
+
+    virtual size_t StaticMemoryUsage() = 0;
+    virtual size_t DynamicMemoryUsage() = 0;
+
     // 1. Receiver side functions, for decoding bytes received on the wire into transport protocol
     // agnostic CNetMessage (message type & payload) objects.
 
@@ -432,6 +436,9 @@ private:
 
 public:
     V1Transport(const NodeId node_id, int nTypeIn, int nVersionIn) noexcept;
+
+    size_t StaticMemoryUsage() override EXCLUSIVE_LOCKS_REQUIRED(!m_recv_mutex, !m_send_mutex);
+    size_t DynamicMemoryUsage() override EXCLUSIVE_LOCKS_REQUIRED(!m_recv_mutex, !m_send_mutex);
 
     bool ReceivedMessageComplete() const override EXCLUSIVE_LOCKS_REQUIRED(!m_recv_mutex)
     {
@@ -631,6 +638,9 @@ private:
     SendState m_send_state GUARDED_BY(m_send_mutex);
     /** Whether we've sent at least 24 bytes (which would trigger disconnect for V1 peers). */
     bool m_sent_v1_header_worth GUARDED_BY(m_send_mutex) {false};
+
+    size_t StaticMemoryUsage() override;
+    size_t DynamicMemoryUsage() override;
 
     /** Change the receive state. */
     void SetReceiveState(RecvState recv_state) noexcept EXCLUSIVE_LOCKS_REQUIRED(m_recv_mutex);

--- a/src/net.h
+++ b/src/net.h
@@ -1563,6 +1563,8 @@ private:
      */
     std::atomic_bool m_start_extra_block_relay_peers{false};
 
+    bool ABCDBool{true};
+
     /**
      * A vector of -bind=<address>:<port>=onion arguments each of which is
      * an address and port that are designated for incoming Tor connections.

--- a/src/net.h
+++ b/src/net.h
@@ -1235,6 +1235,8 @@ public:
     size_t GetNodeCount(ConnectionDirection) const;
     uint32_t GetMappedAS(const CNetAddr& addr) const;
     void GetNodeStats(std::vector<CNodeStats>& vstats) const;
+    void GetNodeMemory(std::map<NodeId, size_t>& info) const;
+    std::string NodeToString(NodeId id) const;
     bool DisconnectNode(const std::string& node);
     bool DisconnectNode(const CSubNet& subnet);
     bool DisconnectNode(const CNetAddr& addr);

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1772,7 +1772,11 @@ size_t Peer::DynamicMemoryUsage()
     {
         LOCK(m_headers_sync_mutex);
         dy += memusage::DynamicUsage(m_headers_sync);
-        if (m_headers_sync) { dy += memusage::DynamicUsage(m_headers_sync->m_redownloaded_headers);}
+        if (m_headers_sync)
+        {
+            dy += memusage::DynamicUsage(m_headers_sync->m_redownloaded_headers);
+            dy += memusage::DynamicUsage(m_headers_sync->m_header_commitments.m_deque);
+        }
     }
 
     LOCK(m_tx_relay_mutex);

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -514,6 +514,7 @@ public:
     std::optional<std::string> FetchBlock(NodeId peer_id, const CBlockIndex& block_index) override
         EXCLUSIVE_LOCKS_REQUIRED(!m_peer_mutex);
     bool GetNodeStateStats(NodeId nodeid, CNodeStateStats& stats) const override EXCLUSIVE_LOCKS_REQUIRED(!m_peer_mutex);
+    std::tuple<size_t, bool, size_t> PeerMemoryInfo(NodeId nodeid) override EXCLUSIVE_LOCKS_REQUIRED(!m_peer_mutex);;
     bool IgnoresIncomingTxs() override { return m_opts.ignore_incoming_txs; }
     void SendPings() override EXCLUSIVE_LOCKS_REQUIRED(!m_peer_mutex);
     void RelayTransaction(const uint256& txid, const uint256& wtxid) override EXCLUSIVE_LOCKS_REQUIRED(!m_peer_mutex);
@@ -1724,6 +1725,27 @@ size_t Peer::ConstantMemoryUsage() const
     val += sizeof(m_tx_relay);
 
     return val;
+}
+
+std::tuple<size_t, bool, size_t> PeerManagerImpl::PeerMemoryInfo(NodeId nodeid)
+{
+    PeerRef peer = GetPeerRef(nodeid);
+    if (!peer) return {0, false, 0};
+
+    size_t current_dynamic_usage = peer->DynamicMemoryUsage();
+    bool relay_txs = false;
+
+    {
+        LOCK(peer->m_tx_relay_mutex);
+        if (peer->m_tx_relay) {
+            LOCK(peer->m_tx_relay->m_bloom_filter_mutex);
+            relay_txs = peer->m_tx_relay->m_relay_txs;
+        }
+    }
+
+    size_t max_dynamic_usage = peer->ongoing_max_memusage;
+
+    return {current_dynamic_usage, relay_txs, max_dynamic_usage};
 }
 
 size_t Peer::DynamicMemoryUsage()

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -730,6 +730,8 @@ private:
       * on extra block-relay-only peers. */
     bool m_initial_sync_finished GUARDED_BY(cs_main){false};
 
+    bool ABCDBool{true};
+
     /** Protects m_peer_map. This mutex must not be locked while holding a lock
      *  on any of the mutexes inside a Peer object. */
     mutable Mutex m_peer_mutex;
@@ -1548,6 +1550,10 @@ void PeerManagerImpl::InitializeNode(CNode& node, ServiceFlags our_services)
         assert(m_txrequest.Count(nodeid) == 0);
     }
     PeerRef peer = std::make_shared<Peer>(nodeid, our_services);
+    if(ABCDBool) {
+        ABCDBool = false;
+        LogPrintf("ABCD Peer::ConstantMemoryUsage - %d \n", peer->ConstantMemoryUsage());
+    }
     {
         LOCK(m_peer_mutex);
         m_peer_map.emplace_hint(m_peer_map.end(), nodeid, peer);

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -397,6 +397,8 @@ struct Peer {
     /** Transaction relay data. May be a nullptr. */
     std::unique_ptr<TxRelay> m_tx_relay GUARDED_BY(m_tx_relay_mutex);
 
+    size_t ConstantMemoryUsage() const;
+
     std::atomic<size_t> inaccessible_dyn_memusage{0};
 };
 
@@ -1660,6 +1662,66 @@ PeerRef PeerManagerImpl::RemovePeer(NodeId id)
         m_peer_map.erase(it);
     }
     return ret;
+}
+
+// sanity check. should be comparable to sizeof(peer)
+size_t Peer::ConstantMemoryUsage() const
+{
+    size_t val = 0;
+
+    val += sizeof(m_id);
+    val += sizeof(m_our_services);
+    val += sizeof(m_their_services);
+
+    val += sizeof(m_misbehavior_mutex);
+    val += sizeof(m_misbehavior_score);
+    val += sizeof(m_should_discourage);
+
+    val += sizeof(m_block_inv_mutex);
+    val += sizeof(m_blocks_for_inv_relay);
+    val += sizeof(m_blocks_for_headers_relay);
+    val += sizeof(m_continuation_block);
+
+    val += sizeof(m_starting_height);
+    val += sizeof(m_ping_nonce_sent);
+    val += sizeof(m_ping_start);
+    val += sizeof(m_ping_queued);
+    val += sizeof(m_wtxid_relay);
+
+    val += sizeof(m_fee_filter_sent);
+    val += sizeof(m_next_send_feefilter);
+
+    val += sizeof(m_addrs_to_send);
+    val += sizeof(m_addr_known);
+    val += sizeof(m_addr_relay_enabled);
+    val += sizeof(m_getaddr_sent);
+    val += sizeof(m_addr_send_times_mutex);
+    val += sizeof(m_next_addr_send);
+    val += sizeof(m_next_local_addr_send);
+
+    val += sizeof(m_wants_addrv2);
+    val += sizeof(m_getaddr_recvd);
+    val += sizeof(m_addr_token_bucket);
+    val += sizeof(m_addr_token_timestamp);
+    val += sizeof(m_addr_rate_limited);
+    val += sizeof(m_addr_processed);
+
+    val += sizeof(m_inv_triggered_getheaders_before_sync);
+    val += sizeof(m_getdata_requests_mutex);
+    val += sizeof(m_getdata_requests);
+    val += sizeof(m_last_getheaders_timestamp);
+    val += sizeof(m_headers_sync_mutex);
+    val += sizeof(m_headers_sync);
+    val += sizeof(m_sent_sendheaders);
+
+    val += sizeof(m_num_unconnecting_headers_msgs);
+    val += sizeof(m_headers_sync_timeout);
+    val += sizeof(m_prefers_headers);
+
+    val += sizeof(m_tx_relay_mutex);
+    val += sizeof(m_tx_relay);
+
+    return val;
 }
 
 bool PeerManagerImpl::GetNodeStateStats(NodeId nodeid, CNodeStateStats& stats) const

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -392,11 +392,12 @@ struct Peer {
         , m_our_services{our_services}
     {}
 
-private:
     mutable Mutex m_tx_relay_mutex;
 
     /** Transaction relay data. May be a nullptr. */
     std::unique_ptr<TxRelay> m_tx_relay GUARDED_BY(m_tx_relay_mutex);
+
+    std::atomic<size_t> inaccessible_dyn_memusage{0};
 };
 
 using PeerRef = std::shared_ptr<Peer>;
@@ -5018,6 +5019,10 @@ bool PeerManagerImpl::ProcessMessages(CNode* pfrom, std::atomic<bool>& interrupt
 
     PeerRef peer = GetPeerRef(pfrom->GetId());
     if (peer == nullptr) return false;
+
+    peer->inaccessible_dyn_memusage = (
+           memusage::DynamicUsage(peer->m_addrs_to_send)
+         + memusage::DynamicUsage(peer->m_addr_known));
 
     {
         LOCK(peer->m_getdata_requests_mutex);

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -398,8 +398,10 @@ struct Peer {
     std::unique_ptr<TxRelay> m_tx_relay GUARDED_BY(m_tx_relay_mutex);
 
     size_t ConstantMemoryUsage() const;
+    size_t DynamicMemoryUsage() EXCLUSIVE_LOCKS_REQUIRED(!m_block_inv_mutex, !m_getdata_requests_mutex, !m_headers_sync_mutex, !m_tx_relay_mutex);
 
     std::atomic<size_t> inaccessible_dyn_memusage{0};
+    std::atomic<size_t> ongoing_max_memusage{0};
 };
 
 using PeerRef = std::shared_ptr<Peer>;
@@ -1722,6 +1724,50 @@ size_t Peer::ConstantMemoryUsage() const
     val += sizeof(m_tx_relay);
 
     return val;
+}
+
+size_t Peer::DynamicMemoryUsage()
+{
+    size_t dy = 0;
+
+    {
+        LOCK(m_block_inv_mutex);
+        dy += memusage::DynamicUsage(m_blocks_for_inv_relay);
+        dy += memusage::DynamicUsage(m_blocks_for_headers_relay);
+    }
+
+    // usage of m_addrs_to_send & m_addr_known
+    dy += inaccessible_dyn_memusage;
+
+    WITH_LOCK(m_getdata_requests_mutex, dy += memusage::DynamicUsage(m_getdata_requests));
+
+    {
+        LOCK(m_headers_sync_mutex);
+        dy += memusage::DynamicUsage(m_headers_sync);
+        if (m_headers_sync) { dy += memusage::DynamicUsage(m_headers_sync->m_redownloaded_headers);}
+    }
+
+    LOCK(m_tx_relay_mutex);
+    if (m_tx_relay)
+    {
+        dy += memusage::DynamicUsage(m_tx_relay);
+
+        {
+            LOCK(m_tx_relay->m_bloom_filter_mutex);
+            dy += memusage::DynamicUsage(m_tx_relay->m_bloom_filter);
+            if (m_tx_relay->m_bloom_filter) {
+                dy += m_tx_relay->m_bloom_filter->DynamicUsage();
+            }
+        }
+
+        {
+            LOCK(m_tx_relay->m_tx_inventory_mutex);
+            dy += m_tx_relay->m_tx_inventory_known_filter.DynamicUsage();
+            dy += memusage::DynamicUsage(m_tx_relay->m_tx_inventory_to_send);
+        }
+    }
+
+    return dy;
 }
 
 bool PeerManagerImpl::GetNodeStateStats(NodeId nodeid, CNodeStateStats& stats) const
@@ -3420,6 +3466,9 @@ void PeerManagerImpl::ProcessMessage(CNode& pfrom, const std::string& msg_type, 
 
     PeerRef peer = GetPeerRef(pfrom.GetId());
     if (peer == nullptr) return;
+
+    size_t mem = peer->DynamicMemoryUsage();
+    if (mem > peer->ongoing_max_memusage) { peer->ongoing_max_memusage = mem; }
 
     if (msg_type == NetMsgType::VERSION) {
         if (pfrom.nVersion != 0) {

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -2815,6 +2815,18 @@ bool PeerManagerImpl::TryLowWorkHeadersSync(Peer& peer, CNode& pfrom, const CBlo
             peer.m_headers_sync.reset(new HeadersSyncState(peer.m_id, m_chainparams.GetConsensus(),
                 chain_start_header, minimum_chain_work));
 
+            LogPrintf("ABCD m_headers_sync now exists\n");
+            auto bitdeque = peer.m_headers_sync->m_header_commitments;
+            LogPrintf("ABCD sizeof bitdeque - %d \n", sizeof(bitdeque));
+            auto stddeque = bitdeque.m_deque;
+            LogPrintf("ABCD m_deque was accessed\n");
+            auto first_element = stddeque[0];
+            LogPrintf("ABCD first element of m_deque was accessed\n");
+            LogPrintf("ABCD sizeof first element %d\n", sizeof(first_element));
+
+            LogPrintf("ABCD dynamic usage of bitdeque - %d \n",
+                    memusage::DynamicUsage(peer.m_headers_sync->m_header_commitments.m_deque));
+
             // Now a HeadersSyncState object for tracking this synchronization
             // is created, process the headers using it as normal. Failures are
             // handled inside of IsContinuationOfLowWorkHeadersSync.

--- a/src/net_processing.h
+++ b/src/net_processing.h
@@ -83,6 +83,9 @@ public:
     /** Get statistics from node state */
     virtual bool GetNodeStateStats(NodeId nodeid, CNodeStateStats& stats) const = 0;
 
+    // returns <current dynamic usage, relay_txs, ongoing max dynamic usage>
+    virtual std::tuple<size_t, bool, size_t> PeerMemoryInfo(NodeId nodeid) = 0;
+
     /** Whether this node ignores txs received over p2p. */
     virtual bool IgnoresIncomingTxs() = 0;
 

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -98,6 +98,61 @@ static RPCHelpMan ping()
     };
 }
 
+static RPCHelpMan getpeermemoryinfo()
+{
+    return RPCHelpMan{
+        "getpeermemoryinfo",
+        "\n how much memory does each peer use? \n",
+        {},
+        RPCResult{
+            RPCResult::Type::ARR, "", "",
+            {
+                {RPCResult::Type::OBJ, "", "",
+                {
+                    {
+                    {RPCResult::Type::NUM, "id", "Peer id"},
+                    {RPCResult::Type::NUM, "dynamic_cnode_memory", "the result of CNode::DynamicMemoryUsage"},
+                    {RPCResult::Type::NUM, "current_peer_memory", "the result of PeerManagerImpl::GetPeerMemory"},
+                    {RPCResult::Type::NUM, "max_dynamic_peer_memory", "the max result of PeerManagerImpl::GetPeerMemory in a ProcessMessage loop"},
+                    {RPCResult::Type::STR, "connection_type", "Type of connection: \n" + Join(CONNECTION_TYPE_DOC, ",\n") + ".\n"},
+                    {RPCResult::Type::BOOL, "relay_txes", "value of relay_tx bool from version message"},
+                }},
+            }},
+        },
+        RPCExamples{
+            HelpExampleCli("getpeermemoryinfo", "")
+            + HelpExampleRpc("getpeermemoryinfo", "")
+        },
+        [&](const RPCHelpMan& self, const JSONRPCRequest& request) -> UniValue
+{
+    NodeContext& node = EnsureAnyNodeContext(request.context);
+    CConnman& connman = EnsureConnman(node);
+    PeerManager& peerman = EnsurePeerman(node);
+
+    UniValue ret(UniValue::VARR);
+
+    // map of node id -> memory usage
+    std::map<int64_t, size_t> info;
+    // call DynamicMemoryUsage on all CNode objects
+    connman.GetNodeMemory(info);
+    for (auto& [node_id, node_memory] : info) {
+        UniValue obj(UniValue::VOBJ);
+        obj.pushKV("id", node_id);
+        obj.pushKV("dynamic_cnode_memory", node_memory);
+
+        auto [current_peer_mem, relay_txs, max_peer_mem] = peerman.PeerMemoryInfo(node_id);
+        obj.pushKV("current_peer_memory", current_peer_mem);
+        obj.pushKV("max_dynamic_peer_memory", max_peer_mem);
+
+        obj.pushKV("connection_type", connman.NodeToString(node_id));
+        obj.pushKV("relay_txs", relay_txs);
+        ret.push_back(obj);
+    }
+
+    return ret;
+},
+    };
+}
 static RPCHelpMan getpeerinfo()
 {
     return RPCHelpMan{
@@ -1154,6 +1209,7 @@ void RegisterNetRPCCommands(CRPCTable& t)
         {"network", &getconnectioncount},
         {"network", &ping},
         {"network", &getpeerinfo},
+        {"network", &getpeermemoryinfo},
         {"network", &addnode},
         {"network", &disconnectnode},
         {"network", &getaddednodeinfo},

--- a/src/streams.h
+++ b/src/streams.h
@@ -191,7 +191,7 @@ public:
  */
 class DataStream
 {
-protected:
+public:
     using vector_type = SerializeData;
     vector_type vch;
     vector_type::size_type m_read_pos{0};

--- a/src/test/fuzz/rpc.cpp
+++ b/src/test/fuzz/rpc.cpp
@@ -141,6 +141,7 @@ const std::vector<std::string> RPC_COMMANDS_SAFE_FOR_FUZZING{
     "getnetworkinfo",
     "getnodeaddresses",
     "getpeerinfo",
+    "getpeermemoryinfo",
     "getprioritisedtransactions",
     "getrawaddrman",
     "getrawmempool",

--- a/src/util/bitdeque.h
+++ b/src/util/bitdeque.h
@@ -123,7 +123,6 @@ public:
     using reverse_iterator = std::reverse_iterator<iterator>;
     using const_reverse_iterator = std::reverse_iterator<const_iterator>;
 
-private:
     /** Deque of bitsets storing the actual bit data. */
     deque_type m_deque;
 


### PR DESCRIPTION
patch to observe memory usage of different types of bitcoin connections 

exposes RPC endpoint `getpeermemoryinfo` to list current memory usage for each peer

currently not included
- `TxRequestTracker`
- `V2Transport`
- `PeerManagerImpl` things that grow in proportion to peers 